### PR TITLE
chore(CHANGELOG): update to v6.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to [dmn-moddle](https://github.com/bpmn-io/dmn-moddle) are d
 
 ___Note:__ Yet to be released changes appear here._
 
+## 7.0.0
+
+* `FEAT`: add pre-built distribution
+* `CHORE`: update to moddle@5.0.1, moddle-xml@8.0.1
+
+### Breaking Changes
+
+* `FEAT`: dropped `lib/` from npm package; import from the root now
+
 ## 6.0.0
 
 ### Breaking Changes


### PR DESCRIPTION
This updates changelog so that a new version of the library can be released.

I've [tested this](https://github.com/bpmn-io/dmn-js/tree/update-to-dmn-moddle-6) with `dmn-js` and it does not seem to be a breaking change.