### PR TITLE
Add biodi@2.0 package

### DIFF
--- a/lib/simple.js
+++ b/lib/simple.js
@@ -8,12 +8,14 @@ import DcPackage from '../resources/dmn/json/dc.json';
 import DiPackage from '../resources/dmn/json/di.json';
 import DmnPackage from '../resources/dmn/json/dmn13.json';
 import DmnDiPackage from '../resources/dmn/json/dmndi13.json';
+import BioDiPackage from '../resources/dmn/bpmn-io/biodi.json';
 
 var packages = {
   dc: DcPackage,
   di: DiPackage,
   dmn: DmnPackage,
   dmndi: DmnDiPackage,
+  biodi: BioDiPackage
 };
 
 export default function(additionalPackages, options) {

--- a/resources/dmn/bpmn-io/biodi.json
+++ b/resources/dmn/bpmn-io/biodi.json
@@ -1,0 +1,52 @@
+{
+  "name": "bpmn.io DI for DMN",
+  "uri": "http://bpmn.io/schema/dmn/biodi/2.0",
+  "prefix": "biodi",
+  "xml": {
+    "tagAlias": "lowerCase"
+  },
+  "types": [
+    {
+      "name": "DecisionTable",
+      "isAbstract": true,
+      "extends": [
+        "dmn:DecisionTable"
+      ],
+      "properties": [
+        {
+          "name": "annotationsWidth",
+          "isAttr": true,
+          "type": "Integer"
+        }
+      ]
+    },
+    {
+      "name": "OutputClause",
+      "isAbstract": true,
+      "extends": [
+        "dmn:OutputClause"
+      ],
+      "properties": [
+        {
+          "name": "width",
+          "isAttr": true,
+          "type": "Integer"
+        }
+      ]
+    },
+    {
+      "name": "InputClause",
+      "isAbstract": true,
+      "extends": [
+        "dmn:InputClause"
+      ],
+      "properties": [
+        {
+          "name": "width",
+          "isAttr": true,
+          "type": "Integer"
+        }
+      ]
+    }
+  ]
+}

--- a/test/fixtures/dmn/biodi/biodi.dmn
+++ b/test/fixtures/dmn/biodi/biodi.dmn
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="Definitions" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.1.0-dev.20200702">
+  <decision id="Decision" name="Decision">
+    <decisionTable id="DecisionTable_046av0s" biodi:annotationsWidth="200">
+      <input id="InputClause" biodi:width="150">
+        <inputExpression id="LiteralExpression_17mnp7i" typeRef="string">
+          <text></text>
+        </inputExpression>
+      </input>
+      <output id="Output" typeRef="string" biodi:width="150" />
+    </decisionTable>
+  </decision>
+</definitions>

--- a/test/spec/xml/read.js
+++ b/test/spec/xml/read.js
@@ -592,4 +592,20 @@ describe('dmn-moddle - read', function() {
 
   });
 
+
+  describe('biodi', function() {
+
+    it('should read biodi', async function() {
+
+      // when
+      const definitions = await read('test/fixtures/dmn/biodi/biodi.dmn');
+
+      // then
+      const decisionTable = definitions.get('drgElement')[0].decisionLogic;
+
+      expect(decisionTable).to.have.property('annotationsWidth', 200);
+      expect(decisionTable.input[0]).to.have.property('width', 150);
+      expect(decisionTable.output[0]).to.have.property('width', 150);
+    });
+  });
 });

--- a/test/spec/xml/roundtrip.js
+++ b/test/spec/xml/roundtrip.js
@@ -48,6 +48,12 @@ describe('dmn-moddle - roundtrip', function() {
 
   });
 
+
+  describe('biodi', function() {
+
+    it('biodi', roundtrip('test/fixtures/dmn/biodi/biodi.dmn'));
+
+  });
 });
 
 

--- a/test/spec/xml/write.js
+++ b/test/spec/xml/write.js
@@ -343,4 +343,64 @@ describe('dmn-moddle - write', function() {
 
   });
 
+
+  describe('biodi', function() {
+
+    it('should write DecisionTable#annotationsWidth', async function() {
+
+      // given
+      const expected = '<dmn:decisionTable ' +
+        'xmlns:dmn="https://www.omg.org/spec/DMN/20191111/MODEL/" ' +
+        'xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" ' +
+        'biodi:annotationsWidth="200" />';
+
+      const decisionTable = moddle.create('dmn:DecisionTable');
+      decisionTable.set('annotationsWidth', 200);
+
+      // when
+      const xml = await write(decisionTable);
+
+      // then
+      expect(xml).to.equal(expected);
+    });
+
+
+    it('should write InputClause#width', async function() {
+
+      // given
+      const expected = '<dmn:inputClause ' +
+        'xmlns:dmn="https://www.omg.org/spec/DMN/20191111/MODEL/" ' +
+        'xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" ' +
+        'biodi:width="200" />';
+
+      const inputClause = moddle.create('dmn:InputClause');
+      inputClause.set('width', 200);
+
+      // when
+      const xml = await write(inputClause);
+
+      // then
+      expect(xml).to.equal(expected);
+    });
+
+
+    it('should write OutputClause#width', async function() {
+
+      // given
+      const expected = '<dmn:outputClause ' +
+        'xmlns:dmn="https://www.omg.org/spec/DMN/20191111/MODEL/" ' +
+        'xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" ' +
+        'biodi:width="200" />';
+
+      const outputClause = moddle.create('dmn:OutputClause');
+      outputClause.set('width', 200);
+
+      // when
+      const xml = await write(outputClause);
+
+      // then
+      expect(xml).to.equal(expected);
+    });
+
+  });
 });


### PR DESCRIPTION
New moddle package contains column width-related properties.
These are:
	* `dmn:DecisionTable#annotationsWidth`
	* `dmn:InputClause#width`
	* `dmn:OutputClause#width`
All of the new properties are of type `Integer` and are supposed
to translate to pixel values of column width.

Related to bpmn-io/dmn-js#500